### PR TITLE
🔴 Add Period Tracking with Firebase Firestore Sync

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,11 @@ android {
 
 dependencies {
     implementation("com.google.firebase:firebase-auth:22.3.0")
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation('com.prolificinteractive:material-calendarview:1.4.3') {
+        exclude group: 'com.android.support'
+    }
+    implementation 'com.google.firebase:firebase-firestore:24.10.1'
     implementation libs.appcompat
     implementation libs.material
     implementation libs.activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
     <!-- 🌐 Internet permission for API calls -->
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -15,37 +14,51 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.RedAlert"
         tools:targetApi="31">
-
-        <!-- ✅ Auth Activities -->
-        <activity android:name=".SignupActivity" android:exported="false" />
-        <activity android:name=".LoginActivity" android:exported="false" />
-
-        <!-- 👤 Profile -->
-        <activity android:name=".UserProfileActivity" android:exported="false" />
-
-        <!-- 🔔 Reminders -->
-        <activity android:name=".ReminderReceiver" android:exported="false" />
-        <activity android:name=".ReminderActivity" android:exported="false" />
-
-        <!-- 💬 Quotes -->
-        <activity android:name=".DailyQuoteActivity" android:exported="false" />
-
-        <!-- 📰 Articles -->
-        <activity android:name=".HealthArticlesActivity" android:exported="false" />
-
-        <!-- 🌼 Tips -->
-        <activity android:name=".TipsActivity" android:exported="false" />
-
-        <!-- 🔮 Predictions -->
-        <activity android:name=".PredictionResultActivity" android:exported="false" />
-        <activity android:name=".StartCycleActivity" android:exported="false" />
-
-        <!-- 🏠 Launcher -->
-        <activity android:name=".MainActivity" android:exported="true">
+        <activity
+            android:name=".PeriodDayDecorator"
+            android:exported="false" />
+        <activity
+            android:name=".CycleCalendarActivity"
+            android:exported="false" /> <!-- ✅ Auth Activities -->
+        <activity
+            android:name=".SignupActivity"
+            android:exported="false" />
+        <activity
+            android:name=".LoginActivity"
+            android:exported="false" /> <!-- 👤 Profile -->
+        <activity
+            android:name=".UserProfileActivity"
+            android:exported="false" /> <!-- 🔔 Reminders -->
+        <activity
+            android:name=".ReminderReceiver"
+            android:exported="false" />
+        <activity
+            android:name=".ReminderActivity"
+            android:exported="false" /> <!-- 💬 Quotes -->
+        <activity
+            android:name=".DailyQuoteActivity"
+            android:exported="false" /> <!-- 📰 Articles -->
+        <activity
+            android:name=".HealthArticlesActivity"
+            android:exported="false" /> <!-- 🌼 Tips -->
+        <activity
+            android:name=".TipsActivity"
+            android:exported="false" /> <!-- 🔮 Predictions -->
+        <activity
+            android:name=".PredictionResultActivity"
+            android:exported="false" />
+        <activity
+            android:name=".StartCycleActivity"
+            android:exported="false" /> <!-- 🏠 Launcher -->
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/example/redalert/CycleCalendarActivity.java
+++ b/app/src/main/java/com/example/redalert/CycleCalendarActivity.java
@@ -1,0 +1,114 @@
+package com.example.redalert;
+
+import android.os.Bundle;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
+import com.prolificinteractive.materialcalendarview.CalendarDay;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public class CycleCalendarActivity extends AppCompatActivity {
+
+    MaterialCalendarView calendarView;
+    TextView selectedDateText;
+
+    FirebaseFirestore db;
+    FirebaseUser user;
+
+    Set<CalendarDay> savedPeriodDays = new HashSet<>();
+    int periodDuration = 4; // Default duration (can be dynamic later)
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_cycle_calendar);
+
+        calendarView = findViewById(R.id.calendarView);
+        selectedDateText = findViewById(R.id.selectedDateText);
+
+        db = FirebaseFirestore.getInstance();
+        user = FirebaseAuth.getInstance().getCurrentUser();
+
+        calendarView.setOnDateChangedListener((widget, date, selected) -> {
+            String formatted = "📅 Selected: " + date.getDay() + "/" + date.getMonth() + "/" + date.getYear();
+            selectedDateText.setText(formatted);
+
+            // Save to Firestore
+            savePeriodToFirestore(date.getDate());
+        });
+
+        loadSavedPeriodData(); // 🔄 Load user's previous periods
+    }
+
+    private void savePeriodToFirestore(Date startDate) {
+        if (user == null) return;
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(startDate);
+
+        Set<CalendarDay> newPeriodDays = new HashSet<>();
+        for (int i = 0; i < periodDuration; i++) {
+            CalendarDay day = CalendarDay.from(calendar);
+            newPeriodDays.add(day);
+
+            String formatted = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.getTime());
+
+            db.collection("users")
+                    .document(user.getUid())
+                    .collection("periods")
+                    .document(formatted)
+                    .set(new PeriodEntry(formatted)); // Save each day
+
+            calendar.add(Calendar.DAY_OF_MONTH, 1); // Go to next day
+        }
+
+        savedPeriodDays.addAll(newPeriodDays);
+        calendarView.addDecorator(new PeriodDayDecorator(savedPeriodDays));
+        Toast.makeText(this, "🩸 Period saved!", Toast.LENGTH_SHORT).show();
+    }
+
+    private void loadSavedPeriodData() {
+        if (user == null) return;
+
+        db.collection("users")
+                .document(user.getUid())
+                .collection("periods")
+                .get()
+                .addOnSuccessListener(query -> {
+                    for (var doc : query.getDocuments()) {
+                        String dateStr = doc.getId();
+                        try {
+                            Date date = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
+                            CalendarDay day = CalendarDay.from(date);
+                            savedPeriodDays.add(day);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    calendarView.addDecorator(new PeriodDayDecorator(savedPeriodDays));
+                })
+                .addOnFailureListener(e -> Toast.makeText(this, "❌ Failed to load periods", Toast.LENGTH_SHORT).show());
+    }
+
+    // Helper class for Firestore
+    public static class PeriodEntry {
+        public String date;
+
+        public PeriodEntry() {} // Needed for Firestore
+        public PeriodEntry(String date) {
+            this.date = date;
+        }
+    }
+}

--- a/app/src/main/java/com/example/redalert/MainActivity.java
+++ b/app/src/main/java/com/example/redalert/MainActivity.java
@@ -29,42 +29,42 @@ public class MainActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_main);
 
-        // 📚 View Health Articles
         Button btnViewArticles = findViewById(R.id.btnViewArticles);
         btnViewArticles.setOnClickListener(v -> {
             startActivity(new Intent(MainActivity.this, HealthArticlesActivity.class));
         });
 
-        // 🔮 Predict Period
         Button btnStartCycle = findViewById(R.id.btnStartCycle);
         btnStartCycle.setOnClickListener(v -> {
             startActivity(new Intent(MainActivity.this, StartCycleActivity.class));
         });
 
-        // 💬 Daily Quote
         Button btnDailyQuote = findViewById(R.id.btnDailyQuote);
         btnDailyQuote.setOnClickListener(v -> {
             startActivity(new Intent(MainActivity.this, DailyQuoteActivity.class));
         });
 
-        // 🔔 Reminder
         Button btnReminder = findViewById(R.id.btnReminder);
         btnReminder.setOnClickListener(v -> {
             startActivity(new Intent(MainActivity.this, ReminderActivity.class));
         });
 
-        // 👤 User Profile
         Button btnUserProfile = findViewById(R.id.btnUserProfile);
         btnUserProfile.setOnClickListener(v -> {
             startActivity(new Intent(MainActivity.this, UserProfileActivity.class));
         });
 
-        // 🚪 Logout
         Button btnLogout = findViewById(R.id.btnLogout);
         btnLogout.setOnClickListener(v -> {
             auth.signOut();
             startActivity(new Intent(MainActivity.this, LoginActivity.class));
             finish();
+        });
+
+        // 🗓️ Cycle Calendar
+        Button btnCalendar = findViewById(R.id.btnCalendar);
+        btnCalendar.setOnClickListener(v -> {
+            startActivity(new Intent(MainActivity.this, CycleCalendarActivity.class));
         });
     }
 }

--- a/app/src/main/java/com/example/redalert/PeriodDayDecorator.java
+++ b/app/src/main/java/com/example/redalert/PeriodDayDecorator.java
@@ -1,0 +1,30 @@
+package com.example.redalert;
+
+import com.prolificinteractive.materialcalendarview.DayViewDecorator;
+import com.prolificinteractive.materialcalendarview.DayViewFacade;
+import com.prolificinteractive.materialcalendarview.CalendarDay;
+
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PeriodDayDecorator implements DayViewDecorator {
+
+    private final HashSet<CalendarDay> periodDays;
+
+    public PeriodDayDecorator(Set<CalendarDay> days) {
+        this.periodDays = new HashSet<>(days);
+    }
+
+    @Override
+    public boolean shouldDecorate(CalendarDay day) {
+        return periodDays.contains(day);
+    }
+
+    @Override
+    public void decorate(DayViewFacade view) {
+        view.setBackgroundDrawable(new ColorDrawable(Color.parseColor("#FFCDD2"))); // light red
+    }
+}

--- a/app/src/main/res/layout/activity_cycle_calendar.xml
+++ b/app/src/main/res/layout/activity_cycle_calendar.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#FFF9F9"
+    android:padding="24dp"
+    android:gravity="center_horizontal">
+
+    <TextView
+        android:id="@+id/selectedDateText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="📅 Select a date"
+        android:textSize="18sp"
+        android:textColor="#6A1B9A"
+        android:layout_marginBottom="24dp" />
+
+    <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+        android:id="@+id/calendarView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -89,6 +89,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="24dp"
+        android:layout_marginHorizontal="32dp" />
+
+    <!-- 🗓️ View Calendar -->
+    <Button
+        android:id="@+id/btnCalendar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="🗓️ View Cycle Calendar"
+        android:textColor="#FFFFFF"
+        android:backgroundTint="#4CAF50"
+        app:layout_constraintTop_toBottomOf="@id/btnLogout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp"
         android:layout_marginBottom="32dp"
         android:layout_marginHorizontal="32dp" />
 

--- a/app/src/main/res/layout/activity_period_day_decorator.xml
+++ b/app/src/main/res/layout/activity_period_day_decorator.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".PeriodDayDecorator">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.enableJetifier=true


### PR DESCRIPTION
This update enables logged-in users to:

- Select period start dates from the calendar.
- Automatically highlight the next 3 days as the active period.
- Store period data in Firestore under each authenticated user's UID.
- Retrieve and re-highlight saved period days on app launch.

Tested successfully with multiple user accounts. Period data is user-specific, like the Flo app. Ready for further enhancements like mood and symptom tracking.
